### PR TITLE
mtl-2.3.1 compatibility

### DIFF
--- a/Geom2D/CubicBezier/Overlap.lhs
+++ b/Geom2D/CubicBezier/Overlap.lhs
@@ -47,6 +47,7 @@ Let's begin with declaring the module and library imports:
 > import Data.Foldable (traverse_)
 > import Data.Functor ((<$>))
 > import Data.List (sortBy, sort, intercalate, intersperse)
+> import Control.Monad
 > import Control.Monad.State.Strict
 > import Lens.Micro
 > import Lens.Micro.TH


### PR DESCRIPTION
mtl-2.3.1 drops the `Control.Monad` reexport, so `import Control.Monad`.